### PR TITLE
fix: remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
----
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
### Purpose for this PR
Now completely switched over to Renovate for dep management, dropping Dependabot.
<!-- Why are you suggesting this change? -->
<!-- Are there other alternatives to consider? -->
